### PR TITLE
Fix indentation in snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,8 +17,8 @@ parts:
     source: https://github.com/nifty-site-manager/nsm-snap/raw/master/nsm.tar
     build-packages:
     - g++
-	stage-packages:
-	- git
+    stage-packages:
+    - git
 
 apps:
   nsm:


### PR DESCRIPTION
The tabs are causing error reports on build.snapcraft.io.